### PR TITLE
Simplify `RedisPipeline`

### DIFF
--- a/Sources/NIORedis/RedisClient.swift
+++ b/Sources/NIORedis/RedisClient.swift
@@ -106,7 +106,7 @@ public final class RedisConnection: RedisClient {
         var logger = Logger(label: "NIORedis.RedisPipeline")
         logger[metadataKey: loggingKeyID] = self.logger[metadataKey: loggingKeyID]
 
-        return NIORedisPipeline(channel: channel, logger: logger)
+        return RedisPipeline(channel: channel, logger: logger)
     }
 
     /// See `RedisClient.send(command:with:)`

--- a/Sources/NIORedis/RedisPipeline.swift
+++ b/Sources/NIORedis/RedisPipeline.swift
@@ -14,29 +14,12 @@ import Logging
 ///
 /// See [https://redis.io/topics/pipelining#redis-pipelining](https://redis.io/topics/pipelining#redis-pipelining)
 /// - Important: The larger the pipeline queue, the more memory both NIORedis and Redis will use.
-public protocol RedisPipeline {
+///
+/// This implements `RedisClient` to use itself for enqueuing commands.
+public final class RedisPipeline {
     /// The number of commands in the pipeline.
-    var count: Int { get }
+    public var count: Int { return queuedCommandResults.count }
 
-    /// Queues an operation executed with the provided `RedisClient` that will be executed in sequence when
-    /// `execute()` is invoked.
-    ///
-    ///     let pipeline = connection.makePipeline()
-    ///         .enqueue { $0.set("my_key", "3") }
-    ///         .enqueue { $0.send(command: "INCR", with: ["my_key"]) }
-    ///
-    /// See `RedisClient`.
-    /// - Parameter operation: The operation specified with `RedisClient` provided.
-    /// - Returns: A self-reference for chaining commands.
-    @discardableResult
-    func enqueue<T>(operation: (RedisClient) -> EventLoopFuture<T>) -> RedisPipeline
-
-    /// Flushes the queue, sending all of the commands to Redis.
-    /// - Returns: An `EventLoopFuture` that resolves the `RESPValue` responses, in the same order as the command queue.
-    func execute() -> EventLoopFuture<[RESPValue]>
-}
-
-public final class NIORedisPipeline {
     private var logger: Logger
     /// The channel being used to send commands with.
     private let channel: Channel
@@ -46,7 +29,7 @@ public final class NIORedisPipeline {
 
     /// Creates a new pipeline queue that will write to the channel provided.
     /// - Parameter channel: The `Channel` to write to.
-    public init(channel: Channel, logger: Logger = Logger(label: "NIORedis.Pipeline")) {
+    public init(channel: Channel, logger: Logger = Logger(label: "NIORedis.RedisPipeline")) {
         self.channel = channel
         self.logger = logger
         self.queuedCommandResults = []
@@ -56,24 +39,33 @@ public final class NIORedisPipeline {
     }
 }
 
-extension NIORedisPipeline: RedisPipeline {
-    /// See `RedisPipeline.count`.
-    public var count: Int {
-        return queuedCommandResults.count
-    }
+// MARK: Enqueue & Execute
 
-    /// See `RedisPipeline.enqueue(operation:)`.
+extension RedisPipeline {
+    /// Queues an operation executed with the provided `RedisClient` that will be executed in
+    /// sequence when `execute()` is invoked.
+    ///
+    ///     let pipeline = connection.makePipeline()
+    ///         .enqueue { $0.set("my_key", to: 3) }
+    ///         .enqueue { $0.increment("my_key") }
+    ///
+    /// See `RedisClient`.
+    /// - Parameter operation: The operation specified with the `RedisClient` provided.
+    /// - Returns: A self-reference for chaining commands.
     @discardableResult
     public func enqueue<T>(operation: (RedisClient) -> EventLoopFuture<T>) -> RedisPipeline {
         // We are passing ourselves in as the executor instance,
-        // and our implementation of `RedisCommandExecutor.send(command:with:) handles the actual queueing.
+        // and our implementation of `RedisClient.send(command:with:) handles the actual queueing.
         _ = operation(self)
         logger.debug("Command queued. Pipeline size: \(count)")
         return self
     }
 
-    /// See `RedisPipeline.execute()`.
-    /// - Important: If any of the commands fail, the remaining commands will not execute and the `EventLoopFuture` will fail.
+    /// Flushes the queue, sending all of the commands to Redis.
+    /// - Important: If any of the commands fail, the remaining commands will not execute
+    ///     and the `EventLoopFuture` will fail.
+    /// - Returns: An `EventLoopFuture` that resolves the `RESPValue` responses,
+    ///     in the same order as the command queue.
     public func execute() -> EventLoopFuture<[RESPValue]> {
         let response = EventLoopFuture<[RESPValue]>.reduce(
             into: [],
@@ -97,14 +89,21 @@ extension NIORedisPipeline: RedisPipeline {
     }
 }
 
-extension NIORedisPipeline: RedisClient {
-    /// See `RedisCommandExecutor.eventLoop`.
-    public var eventLoop: EventLoop { return self.channel.eventLoop }
+// MARK: RedisClient
+
+extension RedisPipeline: RedisClient {
+    /// See `RedisClient.eventLoop`
+    public var eventLoop: EventLoop { return channel.eventLoop }
 
     /// Sends the command and arguments to a buffer to later be flushed when `execute()` is invoked.
-    /// - Note: When working with a `NIORedisPipeline` instance directly, it is preferred to use the
+    /// - Note: When working with a `RedisPipeline` instance directly, it is preferred to use the
     ///     `RedisPipeline.enqueue(operation:)` method instead of `send(command:with:)`.
-    public func send(command: String, with arguments: [RESPValueConvertible] = []) -> EventLoopFuture<RESPValue> {
+    ///
+    /// See `RedisClient.send(command:with:)`
+    public func send(
+        command: String,
+        with arguments: [RESPValueConvertible] = []
+    ) -> EventLoopFuture<RESPValue> {
         let args = arguments.map { $0.convertedToRESPValue() }
 
         let promise = channel.eventLoop.makePromise(of: RESPValue.self)

--- a/Tests/NIORedisTests/RedisPipelineTests.swift
+++ b/Tests/NIORedisTests/RedisPipelineTests.swift
@@ -22,7 +22,7 @@ final class RedisPipelineTests: XCTestCase {
         try? redis.terminate()
     }
 
-    func test_enqueue() {
+    func test_enqueue() throws {
         let pipeline = connection.makePipeline()
 
         pipeline.enqueue { $0.send(command: "PING") }


### PR DESCRIPTION
Motivation:

`RedisPipeline` has a weak use case as a protocol, as it is more than likely 98% of use cases will end up using the `NIORedisPipeline` implementation.

Result:

`RedisPipeline` is more direct in its intended usage, with comment blocks being more clear.