### PR TITLE
Remove `authorize` convenience command method

### DIFF
--- a/Sources/NIORedis/Commands/BasicCommands.swift
+++ b/Sources/NIORedis/Commands/BasicCommands.swift
@@ -25,17 +25,6 @@ extension RedisClient {
             .mapFromRESP()
     }
 
-    /// Request for authentication in a password-protected Redis server.
-    ///
-    /// [https://redis.io/commands/auth](https://redis.io/commands/auth)
-    /// - Parameter password: The password being used to access the Redis server.
-    /// - Returns: An `EventLoopFuture` that resolves when the connection has been authorized, or fails with a `RedisError`.
-    @inlinable
-    public func authorize(with password: String) -> EventLoopFuture<Void> {
-        return send(command: "AUTH", with: [password])
-            .map { _ in return () }
-    }
-
     /// Select the Redis logical database having the specified zero-based numeric index.
     /// - Note: New connections always use the database `0`.
     ///

--- a/Sources/NIORedis/RedisClient.swift
+++ b/Sources/NIORedis/RedisClient.swift
@@ -161,7 +161,8 @@ extension RedisConnection {
                 guard let pw = password else {
                     return eventLoopGroup.next().makeSucceededFuture(client)
                 }
-                return client.authorize(with: pw)
+
+                return client.send(command: "AUTH", with: [pw])
                     .map { _ in return client }
             }
     }


### PR DESCRIPTION
Motivation:

As this command is embedded in the creation of a `RedisConnection` and you authorize an entire connection to a Redis instance - this command serves no purpose and could make it easier for users to shoot themselves in the foot.

Results:

`authorize(with:)` convenience method is removed, and the `RedisConnection.connect` method now sends a raw command