### PR TITLE
Replace `Foundation.Data` with `[UInt8]` type everywhere

### DIFF
--- a/Sources/NIORedis/ChannelHandlers/RedisCommandHandler.swift
+++ b/Sources/NIORedis/ChannelHandlers/RedisCommandHandler.swift
@@ -1,4 +1,4 @@
-import Foundation
+import struct Foundation.UUID
 import Logging
 import NIO
 

--- a/Sources/NIORedis/Commands/BasicCommands.swift
+++ b/Sources/NIORedis/Commands/BasicCommands.swift
@@ -1,4 +1,3 @@
-import Foundation
 import NIO
 
 extension RedisClient {

--- a/Sources/NIORedis/Commands/SetCommands.swift
+++ b/Sources/NIORedis/Commands/SetCommands.swift
@@ -1,4 +1,3 @@
-import Foundation
 import NIO
 
 // MARK: General

--- a/Sources/NIORedis/Extensions/NIO/ClientBootstrap.swift
+++ b/Sources/NIORedis/Extensions/NIO/ClientBootstrap.swift
@@ -1,4 +1,3 @@
-import Foundation
 import NIO
 
 extension ClientBootstrap {

--- a/Sources/NIORedis/RESP/RESPDecoder.swift
+++ b/Sources/NIORedis/RESP/RESPDecoder.swift
@@ -1,4 +1,3 @@
-import Foundation
 import NIO
 
 extension UInt8 {
@@ -143,7 +142,7 @@ extension RESPDecoder {
         guard size > 0 else {
             // Move the tip of the message position
             position += 2
-            return .parsed(.bulkString(Data()))
+            return .parsed(.bulkString([]))
         }
 
         guard let bytes = buffer.copyBytes(at: position, length: expectedRemainingMessageSize) else {
@@ -154,9 +153,9 @@ extension RESPDecoder {
         // of the bulk string content
         position += expectedRemainingMessageSize
 
-        return .parsed(
-            .bulkString(Data(bytes[ ..<size ]))
-        )
+        return .parsed(.bulkString(
+            .init(bytes[..<size])
+        ))
     }
 
     /// See [https://redis.io/topics/protocol#resp-arrays](https://redis.io/topics/protocol#resp-arrays)

--- a/Sources/NIORedis/RESP/RESPValue.swift
+++ b/Sources/NIORedis/RESP/RESPValue.swift
@@ -1,26 +1,26 @@
-import Foundation
-
 /// A representation of a Redis Serialization Protocol (RESP) primitive value.
 ///
 /// See: [https://redis.io/topics/protocol](https://redis.io/topics/protocol)
 public enum RESPValue {
     case null
     case simpleString(String)
-    case bulkString(Data)
+    case bulkString([UInt8])
     case error(RedisError)
     case integer(Int)
     case array([RESPValue])
 
     /// Initializes a `bulkString` by converting the provided string input.
     public init(bulk: String) {
-        self = .bulkString(Data(bulk.utf8))
+        let bytes = [UInt8](bulk.utf8)
+        self = .bulkString(bytes)
     }
 }
 
 extension RESPValue: ExpressibleByStringLiteral {
     /// Initializes a bulk string from a String literal
     public init(stringLiteral value: String) {
-        self = .bulkString(Data(value.utf8))
+        let bytes = [UInt8](value.utf8)
+        self = .bulkString(bytes)
     }
 }
 
@@ -51,15 +51,15 @@ extension RESPValue {
     public var string: String? {
         switch self {
         case .simpleString(let string): return string
-        case .bulkString(let data): return String(bytes: data, encoding: .utf8)
+        case .bulkString(let bytes): return String(bytes: bytes, encoding: .utf8)
         default: return nil
         }
     }
 
-    /// Extracted binary data from `bulkString` representations.
-    public var data: Data? {
-        guard case .bulkString(let data) = self else { return nil }
-        return data
+    /// Extracted byte representation from `bulkString` values.
+    public var bytes: [UInt8]? {
+        guard case let .bulkString(bytes) = self else { return nil }
+        return bytes
     }
 
     /// Extracted container of data elements from `array` representations.

--- a/Sources/NIORedis/RESP/RESPValueConvertible.swift
+++ b/Sources/NIORedis/RESP/RESPValueConvertible.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Capable of converting to / from `RESPValue`.
 public protocol RESPValueConvertible {
     init?(_ value: RESPValue)
@@ -39,7 +37,7 @@ extension String: RESPValueConvertible {
 
     /// See `RESPValueConvertible.convertedToRESPValue()`
     public func convertedToRESPValue() -> RESPValue {
-        return .bulkString(Data(self.utf8))
+        return .bulkString(.init(self.utf8))
     }
 }
 
@@ -56,7 +54,7 @@ extension FixedWidthInteger {
 
     /// See `RESPValueConvertible.convertedToRESPValue()`
     public func convertedToRESPValue() -> RESPValue {
-        return .bulkString(Data(self.description.utf8))
+        return .bulkString(.init(self.description.utf8))
     }
 }
 
@@ -80,7 +78,7 @@ extension Double: RESPValueConvertible {
 
     /// See `RESPValueConvertible.convertedToRESPValue()`
     public func convertedToRESPValue() -> RESPValue {
-        return .bulkString(Data(self.description.utf8))
+        return .bulkString(.init(self.description.utf8))
     }
 }
 
@@ -93,19 +91,7 @@ extension Float: RESPValueConvertible {
 
     /// See `RESPValueConvertible.convertedToRESPValue()`
     public func convertedToRESPValue() -> RESPValue {
-        return .bulkString(Data(self.description.utf8))
-    }
-}
-
-extension Data: RESPValueConvertible {
-    public init?(_ value: RESPValue) {
-        guard let data = value.data else { return nil }
-        self = data
-    }
-
-    /// See `RESPValueConvertible.convertedToRESPValue()`
-    public func convertedToRESPValue() -> RESPValue {
-        return .bulkString(self)
+        return .bulkString(.init(self.description.utf8))
     }
 }
 

--- a/Sources/NIORedis/RedisClient.swift
+++ b/Sources/NIORedis/RedisClient.swift
@@ -1,5 +1,5 @@
+import struct Foundation.UUID
 import Logging
-import Foundation
 import NIO
 import NIOConcurrencyHelpers
 

--- a/Sources/NIORedis/RedisError.swift
+++ b/Sources/NIORedis/RedisError.swift
@@ -1,4 +1,5 @@
-import Foundation
+import protocol Foundation.LocalizedError
+import class Foundation.Thread
 
 /// Errors thrown while working with Redis.
 public struct RedisError: CustomDebugStringConvertible, CustomStringConvertible, LocalizedError {

--- a/Sources/NIORedis/RedisPipeline.swift
+++ b/Sources/NIORedis/RedisPipeline.swift
@@ -1,4 +1,4 @@
-import Foundation
+import struct Foundation.UUID
 import Logging
 
 /// An object that provides a mechanism to "pipeline" multiple Redis commands in sequence,

--- a/Tests/NIORedisTests/ChannelHandlers/RESPDecoder+B2MDTests.swift
+++ b/Tests/NIORedisTests/ChannelHandlers/RESPDecoder+B2MDTests.swift
@@ -39,8 +39,7 @@ final class RESPDecoderByteToMessageDecoderTests: XCTestCase {
 
     func testDecoding_complete_movesReaderIndex() throws {
         for message in RESPDecoderByteToMessageDecoderTests.completeMessages {
-            let messageByteSize = message.convertedToData()
-            XCTAssertEqual(try decodeTest(message).1, messageByteSize.count)
+            XCTAssertEqual(try decodeTest(message).1, message.bytes.count)
         }
     }
 

--- a/Tests/NIORedisTests/ChannelHandlers/RESPEncoder+ParsingTests.swift
+++ b/Tests/NIORedisTests/ChannelHandlers/RESPEncoder+ParsingTests.swift
@@ -12,8 +12,8 @@ final class RESPEncoderParsingTests: XCTestCase {
     }
 
     func testBulkStrings() {
-        let bytes = Data([0x01, 0x02, 0x0a, 0x1b, 0xaa])
-        XCTAssertTrue(testPass(input: .bulkString(bytes), expected: Data("$5\r\n".utf8) + bytes + Data("\r\n".utf8)))
+        let bytes: [UInt8] = [0x01, 0x02, 0x0a, 0x1b, 0xaa]
+        XCTAssertTrue(testPass(input: .bulkString(bytes), expected: "$5\r\n".bytes + bytes + "\r\n".bytes))
         XCTAssertTrue(testPass(input: .init(bulk: "®in§³¾"), expected: "$10\r\n®in§³¾\r\n"))
         XCTAssertTrue(testPass(input: .init(bulk: ""), expected: "$0\r\n\r\n"))
     }
@@ -29,10 +29,10 @@ final class RESPEncoderParsingTests: XCTestCase {
             input: .array([ .integer(3), .simpleString("foo") ]),
             expected: "*2\r\n:3\r\n+foo\r\n"
         ))
-        let bytes = Data([ 0x0a, 0x1a, 0x1b, 0xff ])
+        let bytes: [UInt8] = [ 0x0a, 0x1a, 0x1b, 0xff ]
         XCTAssertTrue(testPass(
             input: .array([ .array([ .integer(10), .bulkString(bytes) ]) ]),
-            expected: Data("*1\r\n*2\r\n:10\r\n$4\r\n".utf8) + bytes + Data("\r\n".utf8)
+            expected: "*1\r\n*2\r\n:10\r\n$4\r\n".bytes + bytes + "\r\n".bytes
         ))
     }
 
@@ -45,7 +45,7 @@ final class RESPEncoderParsingTests: XCTestCase {
         XCTAssertTrue(testPass(input: .null, expected: "$-1\r\n"))
     }
 
-    private func testPass(input: RESPValue, expected: Data) -> Bool {
+    private func testPass(input: RESPValue, expected: [UInt8]) -> Bool {
         let allocator = ByteBufferAllocator()
 
         var comparisonBuffer = allocator.buffer(capacity: expected.count)

--- a/Tests/NIORedisTests/ChannelHandlers/RESPEncoderTests.swift
+++ b/Tests/NIORedisTests/ChannelHandlers/RESPEncoderTests.swift
@@ -33,15 +33,15 @@ final class RESPEncoderTests: XCTestCase {
     }
 
     func testBulkStrings() throws {
-        let bs1 = RESPValue.bulkString(Data([0x01, 0x02, 0x0a, 0x1b, 0xaa]))
+        let bs1 = RESPValue.bulkString([0x01, 0x02, 0x0a, 0x1b, 0xaa])
         try runEncodePass(with: bs1) { XCTAssertEqual($0.readableBytes, 11) }
         XCTAssertNoThrow(try channel.writeOutbound(bs1))
 
-        let bs2 = RESPValue.bulkString("®in§³¾".convertedToData())
+        let bs2 = RESPValue.bulkString("®in§³¾".bytes)
         try runEncodePass(with: bs2) { XCTAssertEqual($0.readableBytes, 17) }
         XCTAssertNoThrow(try channel.writeOutbound(bs2))
 
-        let bs3 = RESPValue.bulkString("".convertedToData())
+        let bs3 = RESPValue.bulkString("".bytes)
         try runEncodePass(with: bs3) { XCTAssertEqual($0.readableBytes, 6) }
         XCTAssertNoThrow(try channel.writeOutbound(bs3))
     }
@@ -65,7 +65,7 @@ final class RESPEncoderTests: XCTestCase {
         try runEncodePass(with: a2) { XCTAssertEqual($0.readableBytes, 14) }
         XCTAssertNoThrow(try channel.writeOutbound(a2))
 
-        let bytes = Data([ 0x0a, 0x1a, 0x1b, 0xff ])
+        let bytes: [UInt8] = [ 0x0a, 0x1a, 0x1b, 0xff ]
         let a3: RESPValue = .array([.array([
             .integer(3),
             .bulkString(bytes)
@@ -78,7 +78,7 @@ final class RESPEncoderTests: XCTestCase {
         let error = RedisError(identifier: "testError", reason: "Manual error")
         let data = RESPValue.error(error)
         try runEncodePass(with: data) {
-            XCTAssertEqual($0.readableBytes, "-\(error.description)\r\n".convertedToData().count)
+            XCTAssertEqual($0.readableBytes, "-\(error.description)\r\n".bytes.count)
         }
         XCTAssertNoThrow(try channel.writeOutbound(data))
     }

--- a/Tests/NIORedisTests/RedisPipelineTests.swift
+++ b/Tests/NIORedisTests/RedisPipelineTests.swift
@@ -55,7 +55,7 @@ final class RedisPipelineTests: XCTestCase {
 
         XCTAssertEqual(results[0].string, "PONG")
         XCTAssertEqual(results[1].string, "OK")
-        XCTAssertEqual(results[2].data, "3".convertedToData())
+        XCTAssertEqual(results[2].bytes, "3".bytes)
     }
 
     func test_executeIsOrdered() throws {

--- a/Tests/NIORedisTests/Utilities/String.swift
+++ b/Tests/NIORedisTests/Utilities/String.swift
@@ -2,5 +2,5 @@ import Foundation
 
 extension String {
     /// Converts this String to a byte representation.
-    func convertedToData() -> Data { return Data(utf8) }
+    var bytes: [UInt8] { return .init(self.utf8) }
 }


### PR DESCRIPTION
Motivation:

`Foundation.Data` is known to be more expensive than is necessary for this low level of a library, and has some quirks with its usage.

Results:

This library now works with byte arrays (`[UInt8]`) directly, and all references to `Foundation` now explicitly import the exact types they need.