### PR TITLE
Add Blocking Sorted Set Pop Commands

### DIFF
--- a/Sources/NIORedis/RedisClient.swift
+++ b/Sources/NIORedis/RedisClient.swift
@@ -76,7 +76,7 @@ public final class RedisConnection: RedisClient {
         }
     }
 
-    private let channel: Channel
+    let channel: Channel
     private var logger: Logger
 
     private let autoflush = Atomic<Bool>(value: true)


### PR DESCRIPTION
Motivation:

To be a comprehensive library, all commands should be implemented, even if they are highly discouraged. Sorted Set's collection of commands were missing `bzpopmin` and `bzpopmax`.

Modifications:

`bzpopmin` and `bzpopmax` are supported with defaults and overloads for an easier API.
`RedisClient.channel` is now `internal` to have access during testing for bypassing normal guards for closing connections.

Result:

Users now have access to `bzpopmin` and `bzpopmax` commands.